### PR TITLE
Task/apps 3360 handle ignored user identification notification

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -90,6 +90,15 @@
             </intent-filter>
         </receiver>
         <service android:name=".services.notifications.DeviceUnlockMonitoringService" />
+        <service
+            android:name=".services.notifications.NotificationListener"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/openlattice/chronicle/receivers/lifecycle/UnlockDeviceReceiver.kt
+++ b/app/src/main/java/com/openlattice/chronicle/receivers/lifecycle/UnlockDeviceReceiver.kt
@@ -83,7 +83,7 @@ class UnlockDeviceReceiver : BroadcastReceiver() {
             .setAutoCancel(true) // remove when user taps on notification
 
         with(NotificationManagerCompat.from(context)) {
-            notify(1, notificationBuilder.build())
+            notify(context.resources.getInteger(R.integer.identify_user_notification_id), notificationBuilder.build())
         }
 
     }

--- a/app/src/main/java/com/openlattice/chronicle/services/notifications/NotificationListener.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/notifications/NotificationListener.kt
@@ -8,6 +8,9 @@ import com.openlattice.chronicle.preferences.EnrollmentSettings
 
 class NotificationListener : NotificationListenerService() {
     override fun onNotificationPosted(sbn: StatusBarNotification?) {
+
+        // When notification to identify user has been posted, unassign current user. If user ignores notification,
+        // subsequent usage events will be assumed to belong to an 'unidentified user'
         if (sbn?.id == applicationContext.resources.getInteger(R.integer.identify_user_notification_id)) {
             Log.i(javaClass.name, "User identification notification posted.")
             EnrollmentSettings(applicationContext).setTargetUser(applicationContext.getString(R.string.user_unassigned))

--- a/app/src/main/java/com/openlattice/chronicle/services/notifications/NotificationListener.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/notifications/NotificationListener.kt
@@ -1,0 +1,16 @@
+package com.openlattice.chronicle.services.notifications
+
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+import android.util.Log
+import com.openlattice.chronicle.R
+import com.openlattice.chronicle.preferences.EnrollmentSettings
+
+class NotificationListener : NotificationListenerService() {
+    override fun onNotificationPosted(sbn: StatusBarNotification?) {
+        if (sbn?.id == applicationContext.resources.getInteger(R.integer.identify_user_notification_id)) {
+            Log.i(javaClass.name, "User identification notification posted.")
+            EnrollmentSettings(applicationContext).setTargetUser(applicationContext.getString(R.string.user_unassigned))
+        }
+    }
+}

--- a/app/src/main/res/values/notificationIds.xml
+++ b/app/src/main/res/values/notificationIds.xml
@@ -2,4 +2,5 @@
 <resources>
     <integer name="dismiss_target_user_notification_id">11</integer>
     <integer name="unlock_phone_monitoring_notification_id">12</integer>
+    <integer name="identify_user_notification_id">13</integer>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <!-- Preference Titles -->
     <string name="identification_header">User Identification </string>
     <string name="battery_optimization_header">Battery Optimization</string>
+    <string name="notification_access">Notification access</string>
 
     <!--    Preference keys -->
     <string name="current_user"> current_user </string>
@@ -75,6 +76,7 @@
     <string name="previous_user"> previous_user</string>
     <string name="current_user_timestamp">current_user_timestamp</string>
     <string name="disable_battery_optimization_dialog">disable_battery_optimization_dialog</string>
+    <string name="enable_notification_access">enable_notification_access</string>
 
   <!-- User-defined Intent actions   -->
     <string name="action_identify_after_reboot">Identify user after reboot</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -20,4 +20,11 @@
             app:summary="Display dialog to disable battery optimization"
             app:defaultValue="false" />
     </PreferenceCategory>
+    <PreferenceCategory app:title="@string/notification_access">
+        <SwitchPreferenceCompat
+            app:key="@string/enable_notification_access"
+            app:title="Enable notification access"
+            app:summary="Allow app to read posted notifications"
+            app:defaultValue="false" />
+    </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This PR handles the case where a user identification notification is displayed on a device and the user ignores it/doesn't tap or swipe away. In this case, the current device user is set to **unknown**, represented by a blank string.

For this to work, user must turn on the "Notification Access" in app settings - see attachment below
<img width="397" alt="Screen Shot 2022-04-04 at 8 35 09 AM" src="https://user-images.githubusercontent.com/15723547/161582095-98aa5941-2972-4440-a724-f803ba4415cd.png">

Turning on this setting displays a "Notification Access" screen where the user has to turn on option for "Chronicle" app
<img width="340" alt="Screen Shot 2022-04-04 at 8 42 25 AM" src="https://user-images.githubusercontent.com/15723547/161582376-116ef684-9317-43fb-ac64-3053df7d6945.png">

