### PR TITLE
Fix Jackson Deserialization Issue

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,8 +31,8 @@ android {
         applicationId "com.openlattice.chronicle"
         minSdkVersion 34
         targetSdkVersion 36
-        versionCode 37
-        versionName "2025-10-14"
+        versionCode 38
+        versionName "2025-10-23"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,7 +96,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation platform('com.google.firebase:firebase-bom:34.4.0')
-    implementation "org.apache.olingo:odata-commons-api:5.0.0"
+    implementation("org.apache.olingo:odata-commons-api:5.0.0")
 
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.google.firebase:firebase-crashlytics'
@@ -112,8 +112,9 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.13.0'
     implementation 'com.squareup.retrofit2:retrofit:3.0.0'
-    implementation('com.methodic:chronicle-api:0.1.6') {
+    implementation('com.methodic:chronicle-api:0.1.6-SNAPSHOT') {
         exclude module: 'guava'
+        exclude group: 'org.apache.olingo'
         exclude module: 'slf4j-api'
     }
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,16 +87,16 @@ ksp {
     arg('room.schemaLocation', "$projectDir/schemas")
 }
 
-ext.jackson_version = '2.19.0'
+ext.jackson_version = '2.20.0'
 ext.activity_version = '1.6.0'
-ext.odata_version='4.5.0'
+
 dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation platform('com.google.firebase:firebase-bom:34.4.0')
-    implementation "org.apache.olingo:odata-commons-api:${odata_version}"
+    implementation "org.apache.olingo:odata-commons-api:5.0.0"
 
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.google.firebase:firebase-crashlytics'
@@ -106,13 +106,13 @@ dependencies {
     implementation "androidx.activity:activity-ktx:1.11.0"
 
     // WorkManager
-    implementation "androidx.work:work-runtime-ktx:2.10.5"
-    implementation "org.apache.commons:commons-lang3:3.17.0"
-    implementation 'com.google.code.gson:gson:2.12.1'
+    implementation "androidx.work:work-runtime-ktx:2.11.0"
+    implementation "org.apache.commons:commons-lang3:3.19.0"
+    implementation 'com.google.code.gson:gson:2.13.2'
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.13.0'
-    implementation 'com.squareup.retrofit2:retrofit:2.11.0'
-    implementation('com.methodic:chronicle-api:0.1.2') {
+    implementation 'com.squareup.retrofit2:retrofit:3.0.0'
+    implementation('com.methodic:chronicle-api:0.1.6') {
         exclude module: 'guava'
         exclude module: 'slf4j-api'
     }
@@ -122,25 +122,25 @@ dependencies {
     }
 
     implementation "com.fasterxml.jackson.core:jackson-core:${jackson_version}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.19.0"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.20.0"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jackson_version}"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-joda:${jackson_version}"
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:${jackson_version}"
 
-    implementation 'joda-time:joda-time:2.12.7'
+    implementation 'joda-time:joda-time:2.14.0'
 
     implementation 'org.slf4j:slf4j-android:1.7.36'
     implementation 'org.slf4j:slf4j-android:1.7.36'
-    implementation 'com.google.guava:guava:31.1-android'
-    implementation 'org.dmfs:lib-recur:0.11.6'
+    implementation 'com.google.guava:guava:33.5.0-android'
+    implementation 'org.dmfs:lib-recur:0.17.1'
 
-    implementation 'androidx.room:room-runtime:2.8.2'
-    implementation 'androidx.room:room-ktx:2.8.2'
+    implementation 'androidx.room:room-runtime:2.8.3'
+    implementation 'androidx.room:room-ktx:2.8.3'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'androidx.preference:preference-ktx:1.2.1'
-    ksp 'androidx.room:room-compiler:2.8.2'
-    annotationProcessor 'androidx.room:room-compiler:2.8.2'
-    implementation 'androidx.room:room-runtime:2.8.2'
+    ksp 'androidx.room:room-compiler:2.8.3'
+    annotationProcessor 'androidx.room:room-compiler:2.8.3'
+    implementation 'androidx.room:room-runtime:2.8.3'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'

--- a/app/src/androidTest/java/com/openlattice/chronicle/ChronicleUploadTests.kt
+++ b/app/src/androidTest/java/com/openlattice/chronicle/ChronicleUploadTests.kt
@@ -51,7 +51,7 @@ class ChronicleUploadTests {
     fun testchronicleReadWriteSingleQueueEntry() {
         val deviceId = Settings.Secure.getString(getContext().getContentResolver(), Settings.Secure.ANDROID_ID);
 
-        val device = AndroidDevice(deviceId, Build.MODEL, Build.VERSION.CODENAME, Build.BRAND, Build.DISPLAY, Build.VERSION.SDK_INT.toString(), Build.PRODUCT, deviceId, Optional.absent())
+        val device = AndroidDevice(deviceId, Build.MODEL, Build.VERSION.CODENAME, Build.BRAND, Build.DISPLAY, Build.VERSION.SDK_INT.toString(), Build.PRODUCT, deviceId, mapOf())
         val studyId = UUID.fromString("28d661b8-a45a-41b6-aec4-ed9988fa28dc")
         val participantId = "participant1"
 

--- a/app/src/main/java/com/openlattice/chronicle/models/ExtractedUsageEvent.kt
+++ b/app/src/main/java/com/openlattice/chronicle/models/ExtractedUsageEvent.kt
@@ -1,10 +1,11 @@
 package com.openlattice.chronicle.models
 
+import com.fasterxml.jackson.annotation.JsonCreator
 import com.openlattice.chronicle.android.ChronicleSample
 import java.time.OffsetDateTime
 import java.util.*
 
-data class ExtractedUsageEvent(
+data class ExtractedUsageEvent @JsonCreator constructor(
     val appPackageName: String,
     val interactionType: String,
     val timestamp: OffsetDateTime,

--- a/app/src/main/java/com/openlattice/chronicle/preferences/EnrollmentSettings.kt
+++ b/app/src/main/java/com/openlattice/chronicle/preferences/EnrollmentSettings.kt
@@ -187,7 +187,7 @@ fun getDevice(deviceId: String): AndroidDevice {
         Build.VERSION.SDK_INT.toString(),
         Build.PRODUCT,
         deviceId,
-        Optional.absent()
+        mapOf()
     )
 }
 

--- a/app/src/main/java/com/openlattice/chronicle/sensors/UsageEventsChronicleSensor.kt
+++ b/app/src/main/java/com/openlattice/chronicle/sensors/UsageEventsChronicleSensor.kt
@@ -12,6 +12,7 @@ import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.*
+import androidx.core.content.edit
 
 const val USAGE_EVENTS_POLL_INTERVAL = 15 * 60 * 1000L
 const val LAST_USAGE_QUERY_TIMESTAMP = "com.openlattice.sensors.LastUsageQueryTimestamp"
@@ -38,7 +39,7 @@ class UsageEventsChronicleSensor(context: Context) : ChronicleSensor {
         )
 
         val usageEvents = usageStatsManager.queryEvents(previousPollTimestamp, currentPollTimestamp)
-        settings.edit().putLong(LAST_USAGE_QUERY_TIMESTAMP, currentPollTimestamp).apply()
+        settings.edit {putLong(LAST_USAGE_QUERY_TIMESTAMP, currentPollTimestamp) }
 
         while (usageEvents.hasNextEvent()) {
             val event: UsageEvents.Event = UsageEvents.Event()

--- a/app/src/main/java/com/openlattice/chronicle/services/upload/UploadWorker.kt
+++ b/app/src/main/java/com/openlattice/chronicle/services/upload/UploadWorker.kt
@@ -117,7 +117,7 @@ class UploadWorker(context: Context, params: WorkerParameters) : Worker(context,
         // If studyApi.enroll(...) fails
         val chronicleId: UUID =
             studyApi.enroll(studyId, participantId, deviceId, getDevice(deviceId))
-        Log.i(TAG, "deviceId: $chronicleId")
+                    Log.i(TAG, "deviceId: $chronicleId")
 
         //Only run the upload job if the device is already enrolled or we are able to properly enroll.
         val queue = chronicleDb.queueEntryData()
@@ -133,6 +133,7 @@ class UploadWorker(context: Context, params: WorkerParameters) : Worker(context,
                     try {
                         JsonSerializer.deserializeQueueEntry(qe)
                     } catch (ex: IOException) {
+                        Log.w(TAG, "Error deserializing. Attempting to use legacy deserializer!")
                         mapLegacyQueueEntry(JsonSerializer.deserializeLegacyQueueEntry(qe))
                     }
                 }

--- a/app/src/test/java/com/openlattice/chronicle/TestChronicleDataSerialization.kt
+++ b/app/src/test/java/com/openlattice/chronicle/TestChronicleDataSerialization.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.guava.GuavaModule
 import com.fasterxml.jackson.datatype.joda.JodaModule
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.openlattice.chronicle.models.ExtractedUsageEvent
 import org.apache.commons.lang3.RandomStringUtils
 import org.junit.Test
@@ -46,5 +47,8 @@ class TestChronicleDataSerialization {
         val json = mapper.writeValueAsString( ChronicleData(usageEvents) )
         println("Json: $json")
         Assert.assertTrue( json.contains ("@class") )
+
+        val deserializedUsageEvents = mapper.readValue<ChronicleData>(json)
+        Assert.assertEquals("Deserialized usage events must match." , usageEvents, deserializedUsageEvents )
     }
 }


### PR DESCRIPTION
Jackson 2.19.0 changed behavior so that you must specify @JsonCreator and constructor keywords explicitly for Kotlin JSON serialization to work. This required upgrading the mobile app to use the latest version of our client library with the proper annotations as deserialization of locally saved usage data was failing. 