### PR TITLE
Need to be able to run full release builds locally to fully verify R8 fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,10 @@ android {
             debuggable true
             signingConfig signingConfigs.chronicle
         }
+        releaseMinified {
+            initWith release
+            signingConfig signingConfigs.chronicle
+        }
     }
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -50,6 +50,14 @@
     <init>(...);
 }
 
+# ── Apache Olingo ────────────────────────────────────────────────────────────
+# FullQualifiedName is serialized via Jackson/Retrofit as both a map key and
+# request body.  R8 release optimizations rename its fields, causing the
+# backend to receive nulls.  (Not caught by debugMinified because debuggable
+# disables the aggressive optimization passes.)
+-keep class org.apache.olingo.** { *; }
+-dontwarn org.apache.olingo.**
+
 # ── chronicle-api dependency ─────────────────────────────────────────────────
 # Prevent R8 from stripping/renaming classes in the API dependency that are
 # used via reflection or Jackson polymorphism.


### PR DESCRIPTION
This also adds fixes for FQN Jackson Serialization into proguard rules.